### PR TITLE
fix(cosmoscmd): remove `vesting` from tx command

### DIFF
--- a/cosmoscmd/root.go
+++ b/cosmoscmd/root.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
-	vestingcli "github.com/cosmos/cosmos-sdk/x/auth/vesting/client/cli"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
@@ -274,7 +273,6 @@ func txCommand(moduleBasics module.BasicManager) *cobra.Command {
 		authcmd.GetEncodeCommand(),
 		authcmd.GetDecodeCommand(),
 		flags.LineBreak,
-		vestingcli.GetTxCmd(),
 	)
 
 	moduleBasics.AddTxCommands(cmd)

--- a/cosmoscmd/root.go
+++ b/cosmoscmd/root.go
@@ -272,7 +272,6 @@ func txCommand(moduleBasics module.BasicManager) *cobra.Command {
 		authcmd.GetBroadcastCommand(),
 		authcmd.GetEncodeCommand(),
 		authcmd.GetDecodeCommand(),
-		flags.LineBreak,
 	)
 
 	moduleBasics.AddTxCommands(cmd)


### PR DESCRIPTION
`vesting` tx cmd is already added in the apps since it's part of the default module.

Therefore, this fix prevent having duplicated `vesting` command under tx and fix https://github.com/tendermint/starport/issues/1403

It's a very small fix, I don't think we need to do an intermediary fix release for this one