### PR TITLE
fix: remove deprecated ReadHomeFlag

### DIFF
--- a/cosmoscmd/root.go
+++ b/cosmoscmd/root.go
@@ -136,8 +136,6 @@ func NewRootCmd(
 		Use:   appName + "d",
 		Short: "Stargate CosmosHub App",
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			initClientCtx = client.ReadHomeFlag(initClientCtx, cmd)
-
 			initClientCtx, err := config.ReadFromClientConfig(initClientCtx)
 			if err != nil {
 				return err


### PR DESCRIPTION
removes the call to the deprecated ReadHomeFlag. This is a necessary step in order to allow for starport generated chains to use the latest release patch of the cosmos-sdk

closes #18 